### PR TITLE
fix: check gateway health endpoint

### DIFF
--- a/inference_gateway/main.py
+++ b/inference_gateway/main.py
@@ -22,6 +22,12 @@ app = FastAPI(title="Inference Gateway", description="Inference gateway server w
 
 
 
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+
 @app.post("/api/inference")
 async def inference(request: InferenceRequest):
     try:

--- a/sandbox/sandbox_manager.py
+++ b/sandbox/sandbox_manager.py
@@ -11,6 +11,7 @@ import traceback
 import subprocess
 
 from enum import Enum
+from urllib.parse import urlsplit, urlunsplit
 
 from utils.docker import build_docker_image
 from utils.logger import debug, info, warn, error
@@ -81,10 +82,18 @@ class SandboxManager:
 
         self._start_watchdog()
 
+    @staticmethod
+    def _gateway_healthcheck_url(gateway_url):
+        parsed = urlsplit(gateway_url)
+        if parsed.path and parsed.path != "/":
+            return gateway_url
+        return urlunsplit((parsed.scheme, parsed.netloc, "/health", parsed.query, parsed.fragment))
+
     def _check_gateway(self, gateway_url):
-        info(f"[SANDBOX] Checking gateway URL: {gateway_url}")
+        healthcheck_url = self._gateway_healthcheck_url(gateway_url)
+        info(f"[SANDBOX] Checking gateway URL: {healthcheck_url}")
         try:
-            requests.get(gateway_url)
+            requests.get(healthcheck_url)
         except Exception as e:
             error(f"[SANDBOX] Gateway URL {gateway_url} is invalid: {e}")
         info(f"[SANDBOX] Gateway URL {gateway_url} is valid")

--- a/tests/test_gateway_healthcheck.py
+++ b/tests/test_gateway_healthcheck.py
@@ -1,0 +1,22 @@
+from sandbox.sandbox_manager import SandboxManager
+
+
+def test_gateway_healthcheck_url_uses_health_for_base_url():
+    assert (
+        SandboxManager._gateway_healthcheck_url("http://192.168.1.10:8000")
+        == "http://192.168.1.10:8000/health"
+    )
+
+
+def test_gateway_healthcheck_url_uses_health_for_root_path():
+    assert (
+        SandboxManager._gateway_healthcheck_url("http://192.168.1.10:8000/")
+        == "http://192.168.1.10:8000/health"
+    )
+
+
+def test_gateway_healthcheck_url_preserves_existing_path():
+    assert (
+        SandboxManager._gateway_healthcheck_url("http://192.168.1.10:8000/api/inference")
+        == "http://192.168.1.10:8000/api/inference"
+    )


### PR DESCRIPTION
Closes #2.

## Summary

- add a lightweight `/health` endpoint to the local inference gateway
- make `SandboxManager._check_gateway()` call `/health` for base gateway URLs instead of `/`
- preserve explicit gateway paths such as `/api/inference`

## Why

The gateway app exposes API routes but no root route, so the sandbox startup check can produce noisy `GET / HTTP/1.1` 404 logs even when the gateway is healthy.

## Test

```bash
.venv/Scripts/python.exe -m pytest -q
```

Result:

```text
3 passed in 0.40s
```
